### PR TITLE
Remove workflow dependencies and update Makefile targets

### DIFF
--- a/.github/workflows/3.create-release.yml
+++ b/.github/workflows/3.create-release.yml
@@ -1,12 +1,6 @@
 name: 3. Create Release
 
 on:
-  workflow_run:
-    branches:
-      - main
-    workflows: ["2. Build and Publish"]
-    types:
-      - completed
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/4.update-changelog.yml
+++ b/.github/workflows/4.update-changelog.yml
@@ -1,4 +1,4 @@
-name: 3. Update Changelog
+name: 4. Update Changelog
 
 on:
   workflow_run:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help validate start stop compose clean get-version test bump-version build docs changelog diagrams
+.PHONY: help validate start stop compose clean get-version test bump-version build docs changelog
 
 help:
 	@echo "make help         -- show this help"
@@ -13,7 +13,6 @@ help:
 	@echo "make build        -- build docker image"
 	@echo "make docs         -- build documentation"
 	@echo "make changelog    -- update changelog"
-	@echo "make diagrams     -- generate diagrams"
 
 validate:
 	./compose.sh validate
@@ -47,6 +46,3 @@ docs:
 
 changelog:
 	./scripts/changelog.sh $(MAKEFLAGS)
-
-diagrams:
-	./scripts/diagrams.sh $(MAKEFLAGS)


### PR DESCRIPTION
Eliminate unnecessary workflow dependencies and remove the diagrams target from the Makefile to streamline the build process.