### PR TITLE
Refactor GitHub workflows for changelog trigger

### DIFF
--- a/.github/workflows/3.create-release.yml
+++ b/.github/workflows/3.create-release.yml
@@ -23,7 +23,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create v$(./scripts/get-version.sh) --generate-notes
-      # - name: Trigger Changelog
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: gh workflow run 4.update-changelog.yml
+      - name: Trigger Changelog
+        run: gh workflow run 4.update-changelog.yml

--- a/.github/workflows/4.update-changelog.yml
+++ b/.github/workflows/4.update-changelog.yml
@@ -1,12 +1,12 @@
 name: 4. Update Changelog
 
 on:
-  workflow_run:
-    workflows: ["3. Create Release"]
-    types:
-      - completed
-    branches:
-      - main
+  # workflow_run:
+  #   workflows: ["3. Create Release"]
+  #   types:
+  #     - completed
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Refactor the GitHub workflows to enable the changelog trigger and remove the workflow_run configuration, streamlining the release process.