### PR TITLE
Update error handling for consistent response formatting

### DIFF
--- a/src/api/core/exceptions/_base.py
+++ b/src/api/core/exceptions/_base.py
@@ -38,7 +38,7 @@ class BaseHTTPException(HTTPException):
             headers     (Optional[Dict[str, str]], optional): Headers. Defaults to None.
         """
 
-        _error = error_enum.value.dict()
+        _error = error_enum.value.model_dump()
 
         if not status_code:
             status_code: int = _error.get("status_code")

--- a/src/api/core/handlers/_http_exception.py
+++ b/src/api/core/handlers/_http_exception.py
@@ -40,7 +40,7 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> BaseRe
 
         _error_code_enum = ErrorCodeEnum.get_by_status_code(status_code=exc.status_code)
         if _error_code_enum:
-            _error = _error_code_enum.value.dict()
+            _error = _error_code_enum.value.model_dump()
 
     return BaseResponse(
         request=request,

--- a/src/api/core/handlers/_method_not_allowed.py
+++ b/src/api/core/handlers/_method_not_allowed.py
@@ -20,7 +20,7 @@ async def method_not_allowed_handler(
         BaseResponse: Response object.
     """
 
-    _error = ErrorCodeEnum.METHOD_NOT_ALLOWED.value.dict()
+    _error = ErrorCodeEnum.METHOD_NOT_ALLOWED.value.model_dump()
     _message: str = _error.get("message")
 
     return BaseResponse(

--- a/src/api/core/handlers/_not_found.py
+++ b/src/api/core/handlers/_not_found.py
@@ -18,7 +18,7 @@ async def not_found_handler(request: Request, exc: HTTPException) -> BaseRespons
         BaseResponse: Response object.
     """
 
-    _error = ErrorCodeEnum.NOT_FOUND.value.dict()
+    _error = ErrorCodeEnum.NOT_FOUND.value.model_dump()
     _message: str = _error.get("message")
 
     if hasattr(exc, "detail") and isinstance(exc.detail, dict):

--- a/src/api/core/handlers/_server_error.py
+++ b/src/api/core/handlers/_server_error.py
@@ -32,7 +32,7 @@ async def server_error_handler(request: Request, exc: Exception) -> BaseResponse
     _request_id: str = request.state.request_id
     _exc_str = str(exc)
     _status_code = _error_enum.value.status_code
-    _error = _error_enum.value.dict()
+    _error = _error_enum.value.model_dump()
     _error["detail"] = _exc_str
     _message: str = _error.get("message")
 

--- a/src/api/core/handlers/_validation_error.py
+++ b/src/api/core/handlers/_validation_error.py
@@ -22,7 +22,7 @@ async def validation_error_handler(
     """
 
     _message = "Validation error!"
-    _error = ErrorCodeEnum.UNPROCESSABLE_ENTITY.value.dict()
+    _error = ErrorCodeEnum.UNPROCESSABLE_ENTITY.value.model_dump()
     _error["description"] = str(exc)
     _error["detail"] = exc.errors()
 


### PR DESCRIPTION
Switch error handling to use `model_dump()` instead of `dict()` to ensure consistent formatting of error responses.