### PR TITLE
Update __all__ export to include 'app' instead of 'api'

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,4 +16,4 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from .api import app, __version__
 
 
-__all__ = ["api", "__version__"]
+__all__ = ["app", "__version__"]


### PR DESCRIPTION
Modify the `__all__` export to ensure it includes 'app' for proper module access.