### PR TITLE
Disable automatic key generation in security configuration

### DIFF
--- a/src/configs/security.yml
+++ b/src/configs/security.yml
@@ -16,7 +16,7 @@ api:
       min_length: 8
       max_length: 128
     asymmetric_keys:
-      auto_generate: true
+      auto_generate: false
       algorithm: "RS256"
       key_size: 2048
       private_key_fname: "private_key.pem"


### PR DESCRIPTION
Disable the automatic generation of asymmetric keys in the security configuration to enhance control over key management.