### PR TITLE
Update Docker configuration and permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -495,3 +495,4 @@ zsdoc/data
 **/logs
 **/tmp
 **/data
+**/modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG DEBIAN_FRONTEND
 ARG FT_API_SLUG
 
 # ARG USE_GPU=false
-ARG PYTHON_VERSION=3.9.20
+ARG PYTHON_VERSION=3.9
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,12 @@ _IS_PUSH_IMAGES=false
 _IS_CLEAN_IMAGES=false
 
 # Calculated variables:
-_IMG_NAME=${IMG_REGISTRY}/${IMG_REPO}
+_IMG_NAME=""
+if [ -n "${IMG_REGISTRY}" ]; then
+	_IMG_NAME="${IMG_REGISTRY}/${IMG_REPO}"
+else
+	_IMG_NAME="${IMG_REPO}"
+fi
 _IMG_FULLNAME=${_IMG_NAME}:${IMG_VERSION}${IMG_SUBTAG}
 _IMG_LATEST_FULLNAME=${_IMG_NAME}:latest${IMG_SUBTAG}
 ## --- Variables --- ##
@@ -163,17 +168,21 @@ main()
 	## --- Menu arguments --- ##
 
 
-	if [ -z "${IMG_REGISTRY:-}" ]; then
-		echoError "Required 'IMG_REGISTRY' environment variable or '--registry=' argument for image registry!"
-		exit 1
-	fi
+	# if [ -z "${IMG_REGISTRY:-}" ]; then
+	# 	echoError "Required 'IMG_REGISTRY' environment variable or '--registry=' argument for image registry!"
+	# 	exit 1
+	# fi
 
 	## --- Init arguments --- ##
 	if [ -n "${BASE_IMAGE:-}" ]; then
 		IMG_ARGS="${IMG_ARGS} --build-arg BASE_IMAGE=${BASE_IMAGE}"
 	fi
 
-	_IMG_NAME=${IMG_REGISTRY}/${IMG_REPO}
+	if [ -n "${IMG_REGISTRY}" ]; then
+		_IMG_NAME="${IMG_REGISTRY}/${IMG_REPO}"
+	else
+		_IMG_NAME="${IMG_REPO}"
+	fi
 	_IMG_FULLNAME=${_IMG_NAME}:${IMG_VERSION}${IMG_SUBTAG}
 	_IMG_LATEST_FULLNAME=${_IMG_NAME}:latest${IMG_SUBTAG}
 

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -17,13 +17,13 @@ main()
 	umask 0002 || exit 2
 	sudo chown -Rc "${USER}:${GROUP}" "${FT_HOME_DIR}" "${FT_API_DATA_DIR}" "${FT_API_LOGS_DIR}" "${FT_API_TMP_DIR}" || exit 2
 	find "${FT_API_DIR}" "${FT_API_DATA_DIR}" -type d -exec chmod 770 {} + || exit 2
-	find "${FT_API_DIR}" "${FT_API_DATA_DIR}" -type f -exec chmod 660 {} + || exit 2
+	find "${FT_API_DIR}" "${FT_API_DATA_DIR}" -type f -not -path "*/scripts/*" -not -path "*/main.py" -exec chmod 660 {} + || exit 2
 	find "${FT_API_DIR}" "${FT_API_DATA_DIR}" -type d -exec chmod ug+s {} + || exit 2
 	find "${FT_API_LOGS_DIR}" "${FT_API_TMP_DIR}" -type d -exec chmod 775 {} + || exit 2
 	find "${FT_API_LOGS_DIR}" "${FT_API_TMP_DIR}" -type f -exec chmod 664 {} + || exit 2
 	find "${FT_API_LOGS_DIR}" "${FT_API_TMP_DIR}" -type d -exec chmod +s {} + || exit 2
 	chmod ug+x "${FT_API_DIR}/main.py" || exit 2
-	echo "${USER} ALL=(ALL) ALL" | sudo tee -a "/etc/sudoers.d/${USER}" > /dev/null || exit 2
+	# echo "${USER} ALL=(ALL) ALL" | sudo tee -a "/etc/sudoers.d/${USER}" > /dev/null || exit 2
 	echo ""
 
 	## Parsing input:


### PR DESCRIPTION
Refine the Docker setup by adjusting the Python version, enhancing the build script for better image name handling, and modifying permissions in the entrypoint script. Additionally, update the .dockerignore to exclude the modules directory.